### PR TITLE
fix: make compatbile for Azure Database for PostgreSQL

### DIFF
--- a/deploy/crds/db.movetokube.com_postgresusers_crd.yaml
+++ b/deploy/crds/db.movetokube.com_postgresusers_crd.yaml
@@ -51,6 +51,8 @@ spec:
               type: string
             postgresGroup:
               type: string
+            postgresLogin:
+              type: string
             postgresRole:
               type: string
             succeeded:
@@ -58,6 +60,7 @@ spec:
           required:
           - databaseName
           - postgresGroup
+          - postgresLogin
           - postgresRole
           - succeeded
           type: object

--- a/pkg/apis/db/v1alpha1/postgresuser_types.go
+++ b/pkg/apis/db/v1alpha1/postgresuser_types.go
@@ -22,6 +22,7 @@ type PostgresUserSpec struct {
 type PostgresUserStatus struct {
 	Succeeded     bool   `json:"succeeded"`
 	PostgresRole  string `json:"postgresRole"`
+	PostgresLogin string `json:"postgresLogin"`
 	PostgresGroup string `json:"postgresGroup"`
 	DatabaseName  string `json:"databaseName"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/pkg/apis/db/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.openapi.go
@@ -11,13 +11,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
+		"./pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
+		"./pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
+		"./pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
+		"./pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
 	}
 }
 
@@ -49,19 +49,19 @@ func schema_pkg_apis_db_v1alpha1_Postgres(ref common.ReferenceCallback) common.O
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/db/v1alpha1.PostgresSpec", "./pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -162,7 +162,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 					},
 					"roles": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresRoles"),
 						},
 					},
 					"schemas": {
@@ -188,7 +188,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"},
+			"./pkg/apis/db/v1alpha1.PostgresRoles"},
 	}
 }
 
@@ -220,19 +220,19 @@ func schema_pkg_apis_db_v1alpha1_PostgresUser(ref common.ReferenceCallback) comm
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/db/v1alpha1.PostgresUserSpec", "./pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 

--- a/pkg/apis/db/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.openapi.go
@@ -11,13 +11,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
-		"./pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
-		"./pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
-		"./pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
 	}
 }
 
@@ -49,19 +49,19 @@ func schema_pkg_apis_db_v1alpha1_Postgres(ref common.ReferenceCallback) common.O
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresSpec"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresStatus"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresSpec", "./pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -162,7 +162,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 					},
 					"roles": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresRoles"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"),
 						},
 					},
 					"schemas": {
@@ -188,7 +188,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresRoles"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"},
 	}
 }
 
@@ -220,19 +220,19 @@ func schema_pkg_apis_db_v1alpha1_PostgresUser(ref common.ReferenceCallback) comm
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserSpec"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserStatus"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresUserSpec", "./pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -293,6 +293,12 @@ func schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"postgresLogin": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"postgresGroup": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -306,7 +312,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"succeeded", "postgresRole", "postgresGroup", "databaseName"},
+				Required: []string{"succeeded", "postgresRole", "postgresLogin", "postgresGroup", "databaseName"},
 			},
 		},
 	}

--- a/pkg/controller/postgres/postgres_controller.go
+++ b/pkg/controller/postgres/postgres_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	dbv1alpha1 "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1"
 	"github.com/movetokube/postgres-operator/pkg/postgres"
@@ -35,7 +36,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	pgPass := utils.MustGetEnv("POSTGRES_PASS")
 	pgUriArgs := utils.MustGetEnv("POSTGRES_URI_ARGS")
 	pgCloudProvider := utils.GetEnv("POSTGRES_CLOUD_PROVIDER")
-	pg, err := postgres.NewPG(pgHost, pgUser, pgPass, pgUriArgs, pgCloudProvider, log.WithName("postgres"))
+	pgDefaultDatabase := utils.GetEnv("POSTGRES_DEFAULT_DATABASE")
+	pg, err := postgres.NewPG(pgHost, pgUser, pgPass, pgUriArgs, pgDefaultDatabase, pgCloudProvider, log.WithName("postgres"))
 	if err != nil {
 		return nil
 	}

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -45,7 +45,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	pgPass := utils.MustGetEnv("POSTGRES_PASS")
 	pgUriArgs := utils.MustGetEnv("POSTGRES_URI_ARGS")
 	pgCloudProvider := utils.GetEnv("POSTGRES_CLOUD_PROVIDER")
-	pg, err := postgres.NewPG(pgHost, pgUser, pgPass, pgUriArgs, pgCloudProvider, log.WithName("postgres"))
+	pgDefaultDatabase := utils.GetEnv("POSTGRES_DEFAULT_DATABASE")
+	pg, err := postgres.NewPG(pgHost, pgUser, pgPass, pgUriArgs, pgDefaultDatabase, pgCloudProvider, log.WithName("postgres"))
 	if err != nil {
 		return nil
 	}

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	dbv1alpha1 "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1"
 	"github.com/movetokube/postgres-operator/pkg/postgres"
@@ -249,7 +250,8 @@ func (r *ReconcilePostgresUser) addFinalizer(reqLogger logr.Logger, m *dbv1alpha
 }
 
 func (r *ReconcilePostgresUser) newSecretForCR(cr *dbv1alpha1.PostgresUser, role, password string) *corev1.Secret {
-	pgUserUrl := fmt.Sprintf("postgresql://%s:%s@%s/%s", role, password, r.pgHost, cr.Status.DatabaseName)
+	login := r.pg.GetLoginForRole(role)
+	pgUserUrl := fmt.Sprintf("postgresql://%s:%s@%s/%s", login, password, r.pgHost, cr.Status.DatabaseName)
 	labels := map[string]string{
 		"app": cr.Name,
 	}
@@ -261,7 +263,7 @@ func (r *ReconcilePostgresUser) newSecretForCR(cr *dbv1alpha1.PostgresUser, role
 		},
 		Data: map[string][]byte{
 			"POSTGRES_URL": []byte(pgUserUrl),
-			"ROLE":         []byte(role),
+			"ROLE":         []byte(login),
 			"PASSWORD":     []byte(password),
 		},
 	}

--- a/pkg/postgres/aws.go
+++ b/pkg/postgres/aws.go
@@ -11,10 +11,10 @@ type awspg struct {
 	pg
 }
 
-func newAWSPG(postgres *pg) (PG, error) {
+func newAWSPG(postgres *pg) PG {
 	return &awspg{
 		*postgres,
-	}, nil
+	}
 }
 
 func (c *awspg) AlterDefaultLoginRole(role, setRole string) error {

--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"fmt"
+	"strings"
+)
+
+type azurepg struct {
+	pg
+}
+
+func newAzurePG(postgres *pg) PG {
+	return &azurepg{
+		*postgres,
+	}
+}
+
+func (azpg *azurepg) GetLoginForRole(role string) string {
+	splitUser := strings.Split(azpg.user, "@")
+	if len(splitUser) > 1 {
+		return fmt.Sprintf("%s@%s", role, splitUser[1])
+	}
+	// Fallback to the role name if there was no <@server> added in the login user, but mostly this will mean there is some wrong configuration
+	return role
+}
+
+func (azpg *azurepg) Connect() error {
+	// Default database for azure is postgres
+	// https://docs.microsoft.com/en-us/azure/postgresql/concepts-servers#managing-your-server
+	azpg.db = GetConnection(azpg.user, azpg.pass, azpg.host, "postgres", azpg.args, azpg.log)
+	return nil
+}

--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -23,7 +23,7 @@ func newAzurePG(postgres *pg) PG {
 }
 
 func (azpg *azurepg) CreateUserRole(role, password string) (string, error) {
-	_, err := azpg.db.Exec(fmt.Sprintf(CREATE_USER_ROLE, role, password))
+	_, err := azpg.pg.CreateUserRole(role, password)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -38,13 +38,6 @@ func (azpg *azurepg) GetRoleForLogin(login string) string {
 	return login
 }
 
-func (azpg *azurepg) Connect() error {
-	// Default database for azure is postgres
-	// https://docs.microsoft.com/en-us/azure/postgresql/concepts-servers#managing-your-server
-	azpg.db = GetConnection(azpg.user, azpg.pass, azpg.host, "postgres", azpg.args, azpg.log)
-	return nil
-}
-
 func (azpg *azurepg) CreateDB(dbname, role string) error {
 	// Have to add the master role to the group role before we can transfer the database owner
 	err := azpg.GrantRole(role, azpg.GetRoleForLogin(azpg.user))

--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -23,11 +23,11 @@ func newAzurePG(postgres *pg) PG {
 }
 
 func (azpg *azurepg) CreateUserRole(role, password string) (string, error) {
-	_, err := azpg.pg.CreateUserRole(role, password)
+	returnedRole, err := azpg.pg.CreateUserRole(role, password)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s@%s", role, azpg.serverName), nil
+	return fmt.Sprintf("%s@%s", returnedRole, azpg.serverName), nil
 }
 
 func (azpg *azurepg) GetRoleForLogin(login string) string {

--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"fmt"
 	"strings"
+
+	"github.com/lib/pq"
 )
 
 type azurepg struct {
@@ -24,9 +26,37 @@ func (azpg *azurepg) GetLoginForRole(role string) string {
 	return role
 }
 
+func (azpg *azurepg) GetRoleForLogin(login string) string {
+	splitUser := strings.Split(azpg.user, "@")
+	if len(splitUser) > 1 {
+		return splitUser[0]
+	}
+	return login
+}
+
 func (azpg *azurepg) Connect() error {
 	// Default database for azure is postgres
 	// https://docs.microsoft.com/en-us/azure/postgresql/concepts-servers#managing-your-server
 	azpg.db = GetConnection(azpg.user, azpg.pass, azpg.host, "postgres", azpg.args, azpg.log)
+	return nil
+}
+
+func (azpg *azurepg) CreateDB(dbname, role string) error {
+	_, err := azpg.db.Exec(fmt.Sprintf(CREATE_DB, dbname))
+	if err != nil {
+		// eat DUPLICATE DATABASE ERROR
+		if err.(*pq.Error).Code != "42P04" {
+			return err
+		}
+	}
+	// Have to add the master role to the group role before we can transfer the database owner
+	err = azpg.GrantRole(role, azpg.GetRoleForLogin(azpg.user))
+	if err != nil {
+		return err
+	}
+	_, err = azpg.db.Exec(fmt.Sprintf(ALTER_DB_OWNER, dbname, role))
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -13,7 +13,7 @@ type PG interface {
 	CreateDB(dbname, username string) error
 	CreateSchema(db, role, schema string, logger logr.Logger) error
 	CreateGroupRole(role string) error
-	CreateUserRole(role, password string) error
+	CreateUserRole(role, password string) (string, error)
 	UpdatePassword(role, password string) error
 	GrantRole(role, grantee string) error
 	SetSchemaPrivileges(db, creator, role, schema, privs string, logger logr.Logger) error
@@ -22,7 +22,6 @@ type PG interface {
 	DropDatabase(db string, logger logr.Logger) error
 	DropRole(role, newOwner, database string, logger logr.Logger) error
 	GetUser() string
-	GetLoginForRole(role string) string
 }
 
 type pg struct {
@@ -56,10 +55,6 @@ func NewPG(host, user, password, uri_args, cloud_type string, logger logr.Logger
 
 func (c *pg) GetUser() string {
 	return c.user
-}
-
-func (c *pg) GetLoginForRole(role string) string {
-	return role
 }
 
 func (c *pg) Connect() error {

--- a/pkg/postgres/role.go
+++ b/pkg/postgres/role.go
@@ -28,12 +28,12 @@ func (c *pg) CreateGroupRole(role string) error {
 	return nil
 }
 
-func (c *pg) CreateUserRole(role, password string) error {
+func (c *pg) CreateUserRole(role, password string) (string, error) {
 	_, err := c.db.Exec(fmt.Sprintf(CREATE_USER_ROLE, role, password))
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return role, nil
 }
 
 func (c *pg) GrantRole(role, grantee string) error {


### PR DESCRIPTION
Username is of format <user@name> in Azure, and dbname is defaulting to username*. This causes to be unable to log on, even with the correct credentials. If we pass a database that exists (eg. postgres), it works.

I don't think it's ready to be merged to master, but I don't know which steps I need to take to be OK for the operator hub. (operator.yml expects that the secret has a POSTGRES_DEFAULT_DATABASE value)

* https://www.postgresql.org/docs/10/libpq-connect.html