### PR TITLE
feat: add support to create extensions on database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 gen:
 	operator-sdk generate k8s
+	operator-sdk generate openapi
 build:
 	operator-sdk build movetokube/postgres-operator
 	docker push movetokube/postgres-operator

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 gen:
 	operator-sdk generate k8s
-	operator-sdk generate openapi
+	operator-sdk generate crds
 build:
 	operator-sdk build movetokube/postgres-operator
 	docker push movetokube/postgres-operator

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Cloud specific configuration
 ### AWS
-In order for this operator to work correctly with AWS RDS, you need to set `POSTGRES_CLOUD_PROVIDER` to `AWS` either in 
+In order for this operator to work correctly with AWS RDS, you need to set `POSTGRES_CLOUD_PROVIDER` to `AWS` either in
 the ext-postgres-operator kubernetes secret or directly in the deployment manifest (`operator.yaml`).
 
 ### Azure Database for PostgreSQL
@@ -20,9 +20,9 @@ In order for this operator to work correctly with Azure managed PostgreSQL datab
 * `POSTGRES_DEFAULT_DATABASE` set to your default database, i.e. `postgres`
 
 ## Installation
-This operator requires a Kubernetes Secret to be created in the same namespace as operator itself. 
+This operator requires a Kubernetes Secret to be created in the same namespace as operator itself.
 Secret should contain these keys: POSTGRES_HOST, POSTGRES_USER, POSTGRES_PASS, POSTGRES_URI_ARGS, POSTGRES_CLOUD_PROVIDER, POSTGRES_DEFAULT_DATABASE.
-Example: 
+Example:
 
 ```yaml
 apiVersion: v1
@@ -42,7 +42,7 @@ data:
 
 To install the operator, follow the steps below.
 
-1. Configure Postgres credentials for the operator in `deploy/secret.yaml` 
+1. Configure Postgres credentials for the operator in `deploy/secret.yaml`
 2. `kubectl apply -f deploy/crds/db.movetokube.com_postgres_crd.yaml`
 3. `kubectl apply -f deploy/crds/db.movetokube.com_postgresusers_crd.yaml`
 4. `kubectl apply -f deploy/namespace.yaml`
@@ -63,11 +63,14 @@ metadata:
   namespace: app
 spec:
   database: test-db # Name of database created in PostgreSQL
-  dropOnDelete: false # Set to true if you want the operator to drop the database and role when this CR is deleted
-  masterRole: test-db-group
-  schemas: # List of schemas the operator should create in database
+  dropOnDelete: false # Set to true if you want the operator to drop the database and role when this CR is deleted (optional)
+  masterRole: test-db-group (optional)
+  schemas: # List of schemas the operator should create in database (optional)
   - stores
   - customers
+  extensions: # List of extensions that sould be added in the database (optional)
+  - fuzzystrmatch
+  - pgcrypto
 ```
 
 This creates a database called `test-db` and a role `test-db-group` that is set as the owner of the database.
@@ -92,3 +95,15 @@ This creates a user role `username-<hash>` and grants role `test-db-group`, `tes
 `PostgresUser` needs to reference a `Postgres` in the same namespace.
 
 Two `Postgres` referencing the same database can exist in more than one namespace. The last CR referencing a database will drop the group role and transfer database ownership to the role used by the operator.
+
+## Installation
+
+1. Configure Postgres credentials for the operator in `deploy/operator.yaml`
+2. `kubectl apply -f deploy/crds/db.movetokube.com_postgres_crd.yaml`
+3. `kubectl apply -f deploy/crds/db.movetokube.com_postgresusers_crd.yaml`
+4. `kubectl apply -f deploy/namespace.yaml`
+5. `kubectl apply -f role.yaml`
+6. `kubectl apply -f role_binding.yaml`
+7. `kubectl apply -f service_account.yaml`
+8. `kubectl apply -f operator.yaml`
+

--- a/README.md
+++ b/README.md
@@ -95,15 +95,3 @@ This creates a user role `username-<hash>` and grants role `test-db-group`, `tes
 `PostgresUser` needs to reference a `Postgres` in the same namespace.
 
 Two `Postgres` referencing the same database can exist in more than one namespace. The last CR referencing a database will drop the group role and transfer database ownership to the role used by the operator.
-
-## Installation
-
-1. Configure Postgres credentials for the operator in `deploy/operator.yaml`
-2. `kubectl apply -f deploy/crds/db.movetokube.com_postgres_crd.yaml`
-3. `kubectl apply -f deploy/crds/db.movetokube.com_postgresusers_crd.yaml`
-4. `kubectl apply -f deploy/namespace.yaml`
-5. `kubectl apply -f role.yaml`
-6. `kubectl apply -f role_binding.yaml`
-7. `kubectl apply -f service_account.yaml`
-8. `kubectl apply -f operator.yaml`
-

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ spec:
   schemas: # List of schemas the operator should create in database (optional)
   - stores
   - customers
-  extensions: # List of extensions that sould be added in the database (optional)
+  extensions: # List of extensions that should be created in the database (optional)
   - fuzzystrmatch
   - pgcrypto
 ```

--- a/deploy/crds/db.movetokube.com_postgres_crd.yaml
+++ b/deploy/crds/db.movetokube.com_postgres_crd.yaml
@@ -35,6 +35,10 @@ spec:
               type: string
             dropOnDelete:
               type: boolean
+            extensions:
+              items:
+                type: string
+              type: array
             masterRole:
               type: string
             schemas:
@@ -47,6 +51,10 @@ spec:
         status:
           description: PostgresStatus defines the observed state of Postgres
           properties:
+            extensions:
+              items:
+                type: string
+              type: array
             roles:
               description: PostgresRoles stores the different group roles for database
               properties:

--- a/pkg/apis/db/v1alpha1/postgres_types.go
+++ b/pkg/apis/db/v1alpha1/postgres_types.go
@@ -18,8 +18,8 @@ type PostgresSpec struct {
 	// +optional
 	// +listType=set
 	Schemas []string `json:"schemas,omitempty"`
-	// +listType=set
 	// +optional
+	// +listType=set
 	Extensions []string `json:"extensions,omitempty"`
 }
 
@@ -31,8 +31,8 @@ type PostgresStatus struct {
 	// +optional
 	// +listType=set
 	Schemas []string `json:"schemas,omitempty"`
-	// +listType=set
 	// +optional
+	// +listType=set
 	Extensions []string `json:"extensions,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/db/v1alpha1/postgres_types.go
+++ b/pkg/apis/db/v1alpha1/postgres_types.go
@@ -18,6 +18,9 @@ type PostgresSpec struct {
 	// +optional
 	// +listType=set
 	Schemas []string `json:"schemas,omitempty"`
+	// +listType=set
+	// +optional
+	Extensions []string `json:"extensions,omitempty"`
 }
 
 // PostgresStatus defines the observed state of Postgres
@@ -28,6 +31,9 @@ type PostgresStatus struct {
 	// +optional
 	// +listType=set
 	Schemas []string `json:"schemas,omitempty"`
+	// +listType=set
+	// +optional
+	Extensions []string `json:"extensions,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html

--- a/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Extensions != nil {
+		in, out := &in.Extensions, &out.Extensions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -112,6 +117,11 @@ func (in *PostgresStatus) DeepCopyInto(out *PostgresStatus) {
 	out.Roles = in.Roles
 	if in.Schemas != nil {
 		in, out := &in.Schemas, &out.Schemas
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Extensions != nil {
+		in, out := &in.Extensions, &out.Extensions
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/db/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.openapi.go
@@ -11,13 +11,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
-		"./pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
-		"./pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
-		"./pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
-		"./pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
+		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
 	}
 }
 
@@ -49,19 +49,19 @@ func schema_pkg_apis_db_v1alpha1_Postgres(ref common.ReferenceCallback) common.O
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresSpec"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresStatus"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresSpec", "./pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -140,6 +140,24 @@ func schema_pkg_apis_db_v1alpha1_PostgresSpec(ref common.ReferenceCallback) comm
 							},
 						},
 					},
+					"extensions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"database"},
 			},
@@ -162,10 +180,28 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 					},
 					"roles": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresRoles"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"),
 						},
 					},
 					"schemas": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"extensions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "set",
@@ -188,7 +224,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresRoles"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"},
 	}
 }
 
@@ -220,19 +256,19 @@ func schema_pkg_apis_db_v1alpha1_PostgresUser(ref common.ReferenceCallback) comm
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserSpec"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserStatus"),
+							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/db/v1alpha1.PostgresUserSpec", "./pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 

--- a/pkg/apis/db/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.openapi.go
@@ -11,13 +11,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
-		"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
+		"./pkg/apis/db/v1alpha1.Postgres":           schema_pkg_apis_db_v1alpha1_Postgres(ref),
+		"./pkg/apis/db/v1alpha1.PostgresRoles":      schema_pkg_apis_db_v1alpha1_PostgresRoles(ref),
+		"./pkg/apis/db/v1alpha1.PostgresSpec":       schema_pkg_apis_db_v1alpha1_PostgresSpec(ref),
+		"./pkg/apis/db/v1alpha1.PostgresStatus":     schema_pkg_apis_db_v1alpha1_PostgresStatus(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUser":       schema_pkg_apis_db_v1alpha1_PostgresUser(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUserSpec":   schema_pkg_apis_db_v1alpha1_PostgresUserSpec(ref),
+		"./pkg/apis/db/v1alpha1.PostgresUserStatus": schema_pkg_apis_db_v1alpha1_PostgresUserStatus(ref),
 	}
 }
 
@@ -49,19 +49,19 @@ func schema_pkg_apis_db_v1alpha1_Postgres(ref common.ReferenceCallback) common.O
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/db/v1alpha1.PostgresSpec", "./pkg/apis/db/v1alpha1.PostgresStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -180,7 +180,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 					},
 					"roles": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresRoles"),
 						},
 					},
 					"schemas": {
@@ -224,7 +224,7 @@ func schema_pkg_apis_db_v1alpha1_PostgresStatus(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresRoles"},
+			"./pkg/apis/db/v1alpha1.PostgresRoles"},
 	}
 }
 
@@ -256,19 +256,19 @@ func schema_pkg_apis_db_v1alpha1_PostgresUser(ref common.ReferenceCallback) comm
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus"),
+							Ref: ref("./pkg/apis/db/v1alpha1.PostgresUserStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserSpec", "github.com/movetokube/postgres-operator/pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/db/v1alpha1.PostgresUserSpec", "./pkg/apis/db/v1alpha1.PostgresUserStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 

--- a/pkg/controller/postgres/postgres_controller.go
+++ b/pkg/controller/postgres/postgres_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
+
 	"github.com/movetokube/postgres-operator/pkg/config"
 
 	"github.com/go-logr/logr"
@@ -170,11 +171,11 @@ func (r *ReconcilePostgres) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 	// create extensions
 	for _, extension := range instance.Spec.Extensions {
-		// Check if extension is already added
+		// Check if extension is already added. Skip if already is added.
 		if utils.ListContains(instance.Status.Extensions, extension) {
 			continue
 		}
-		// Create schema
+		// Execute create extension SQL statement
 		err = r.pg.CreateExtension(instance.Spec.Database, extension, reqLogger)
 		if err != nil {
 			reqLogger.Error(err, fmt.Sprintf("Could not add extensions %s", extension))

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -261,7 +261,7 @@ func (r *ReconcilePostgresUser) newSecretForCR(cr *dbv1alpha1.PostgresUser, role
 		},
 		Data: map[string][]byte{
 			"POSTGRES_URL": []byte(pgUserUrl),
-			"ROLE":         []byte(login),
+			"ROLE":         []byte(role),
 			"PASSWORD":     []byte(password),
 			"LOGIN":        []byte(login),
 		},

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -261,7 +261,7 @@ func (r *ReconcilePostgresUser) newSecretForCR(cr *dbv1alpha1.PostgresUser, role
 		},
 		Data: map[string][]byte{
 			"POSTGRES_URL": []byte(pgUserUrl),
-			"ROLE":         []byte(role),
+			"ROLE":         []byte(login),
 			"PASSWORD":     []byte(password),
 			"LOGIN":        []byte(login),
 		},

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -10,6 +10,7 @@ import (
 const (
 	CREATE_DB            = `CREATE DATABASE "%s"`
 	CREATE_SCHEMA        = `CREATE SCHEMA IF NOT EXISTS "%s" AUTHORIZATION "%s"`
+	CREATE_EXTENSION     = `CREATE EXTENSION IF NOT EXISTS "%s"`
 	ALTER_DB_OWNER       = `ALTER DATABASE "%s" OWNER TO "%s"`
 	DROP_DATABASE        = `DROP DATABASE "%s"`
 	GRANT_USAGE_SCHEMA   = `GRANT USAGE ON SCHEMA "%s" TO "%s"`
@@ -33,6 +34,17 @@ func (c *pg) CreateDB(dbname, role string) error {
 	return nil
 }
 
+func (c *pg) CreateSchema(db, role, schema string, logger logr.Logger) error {
+	tmpDb := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	defer tmpDb.Close()
+
+	_, err := tmpDb.Exec(fmt.Sprintf(CREATE_SCHEMA, schema, role))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *pg) DropDatabase(database string, logger logr.Logger) error {
 	_, err := c.db.Exec(fmt.Sprintf(DROP_DATABASE, database))
 	// Error code 3D000 is returned if database doesn't exist
@@ -45,11 +57,11 @@ func (c *pg) DropDatabase(database string, logger logr.Logger) error {
 	return nil
 }
 
-func (c *pg) CreateSchema(db, role, schema string, logger logr.Logger) error {
+func (c *pg) CreateExtension(db, extension string, logger logr.Logger) error {
 	tmpDb := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
 	defer tmpDb.Close()
 
-	_, err := tmpDb.Exec(fmt.Sprintf(CREATE_SCHEMA, schema, role))
+	_, err := tmpDb.Exec(fmt.Sprintf(CREATE_EXTENSION, extension))
 	if err != nil {
 		return err
 	}

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -9,7 +9,6 @@ import (
 )
 
 type PG interface {
-	Connect() error
 	CreateDB(dbname, username string) error
 	CreateSchema(db, role, schema string, logger logr.Logger) error
 	CreateExtension(db, extension string, logger logr.Logger) error
@@ -52,17 +51,10 @@ func NewPG(host, user, password, uri_args, default_database, cloud_type string, 
 	default:
 		return postgres, nil
 	}
-	postgres.Connect()
-	return postgres, nil
 }
 
 func (c *pg) GetUser() string {
 	return c.user
-}
-
-func (c *pg) Connect() error {
-	c.db = GetConnection(c.user, c.pass, c.host, "", c.args, c.log)
-	return nil
 }
 
 func GetConnection(user, password, host, database, uri_args string, logger logr.Logger) *sql.DB {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -9,6 +9,7 @@ import (
 )
 
 type PG interface {
+	Connect() error
 	CreateDB(dbname, username string) error
 	CreateSchema(db, role, schema string, logger logr.Logger) error
 	CreateGroupRole(role string) error
@@ -21,6 +22,7 @@ type PG interface {
 	DropDatabase(db string, logger logr.Logger) error
 	DropRole(role, newOwner, database string, logger logr.Logger) error
 	GetUser() string
+	GetLoginForRole(role string) string
 }
 
 type pg struct {
@@ -50,10 +52,21 @@ func NewPG(host, user, password, uri_args, default_database, cloud_type string, 
 	default:
 		return postgres, nil
 	}
+	postgres.Connect()
+	return postgres, nil
 }
 
 func (c *pg) GetUser() string {
 	return c.user
+}
+
+func (c *pg) GetLoginForRole(role string) string {
+	return role
+}
+
+func (c *pg) Connect() error {
+	c.db = GetConnection(c.user, c.pass, c.host, "", c.args, c.log)
+	return nil
 }
 
 func GetConnection(user, password, host, database, uri_args string, logger logr.Logger) *sql.DB {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -22,7 +22,6 @@ type PG interface {
 	DropDatabase(db string, logger logr.Logger) error
 	DropRole(role, newOwner, database string, logger logr.Logger) error
 	GetUser() string
-	GetLoginForRole(role string) string
 }
 
 type pg struct {
@@ -58,10 +57,6 @@ func NewPG(host, user, password, uri_args, default_database, cloud_type string, 
 
 func (c *pg) GetUser() string {
 	return c.user
-}
-
-func (c *pg) GetLoginForRole(role string) string {
-	return role
 }
 
 func (c *pg) Connect() error {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -12,6 +12,7 @@ type PG interface {
 	Connect() error
 	CreateDB(dbname, username string) error
 	CreateSchema(db, role, schema string, logger logr.Logger) error
+	CreateExtension(db, extension string, logger logr.Logger) error
 	CreateGroupRole(role string) error
 	CreateUserRole(role, password string) (string, error)
 	UpdatePassword(role, password string) error


### PR DESCRIPTION
I've made the changes on the azure branch (sorry, but it made it easier for me!), so this cannot be reviewed/merged until #21 is merged. I will rebase if #21 is closed.
---
This PR adds support for adding creating extensions in the Postgres CRD.
As in most cases I think, only a superuser can activate extensions to the database. That's why it would be great that the operator als handles the extensions for a database, so no special rights have to be given to a user.