### PR TITLE
Add secretName to Postgres CR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ metadata:
   namespace: app
 spec:
   database: test-db # Name of database created in PostgreSQL
+  secretName: my-secret
   dropOnDelete: false # Set to true if you want the operator to drop the database and role when this CR is deleted (optional)
   masterRole: test-db-group (optional)
   schemas: # List of schemas the operator should create in database (optional)


### PR DESCRIPTION
During deployment of this operator it couldn't create the secret because it was missing a part of the secret name. The readme currently only shows the `secretName` on the user example and not on the database example. While for this operator to work both are required.