### PR TITLE
fix: Deleting Postgres CR should delete PostgresUsers

### DIFF
--- a/pkg/postgres/mock/postgres.go
+++ b/pkg/postgres/mock/postgres.go
@@ -215,3 +215,17 @@ func (mr *MockPGMockRecorder) GetUser() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockPG)(nil).GetUser))
 }
+
+// GetDefaultDatabase mocks base method
+func (m *MockPG) GetDefaultDatabase() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultDatabase")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetDefaultDatabase indicates an expected call of GetDefaultDatabase
+func (mr *MockPGMockRecorder) GetDefaultDatabase() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultDatabase", reflect.TypeOf((*MockPG)(nil).GetUser))
+}

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -22,25 +22,28 @@ type PG interface {
 	DropDatabase(db string, logger logr.Logger) error
 	DropRole(role, newOwner, database string, logger logr.Logger) error
 	GetUser() string
+	GetDefaultDatabase() string
 }
 
 type pg struct {
-	db   *sql.DB
-	log  logr.Logger
-	host string
-	user string
-	pass string
-	args string
+	db               *sql.DB
+	log              logr.Logger
+	host             string
+	user             string
+	pass             string
+	args             string
+	default_database string
 }
 
 func NewPG(host, user, password, uri_args, default_database, cloud_type string, logger logr.Logger) (PG, error) {
 	postgres := &pg{
-		db:   GetConnection(user, password, host, default_database, uri_args, logger),
-		log:  logger,
-		host: host,
-		user: user,
-		pass: password,
-		args: uri_args,
+		db:               GetConnection(user, password, host, default_database, uri_args, logger),
+		log:              logger,
+		host:             host,
+		user:             user,
+		pass:             password,
+		args:             uri_args,
+		default_database: default_database,
 	}
 
 	switch cloud_type {
@@ -55,6 +58,10 @@ func NewPG(host, user, password, uri_args, default_database, cloud_type string, 
 
 func (c *pg) GetUser() string {
 	return c.user
+}
+
+func (c *pg) GetDefaultDatabase() string {
+	return c.default_database
 }
 
 func GetConnection(user, password, host, database, uri_args string, logger logr.Logger) *sql.DB {

--- a/pkg/postgres/role.go
+++ b/pkg/postgres/role.go
@@ -65,17 +65,20 @@ func (c *pg) DropRole(role, newOwner, database string, logger logr.Logger) error
 	tmpDb := GetConnection(c.user, c.pass, c.host, database, c.args, logger)
 	_, err := tmpDb.Exec(fmt.Sprintf(REASIGN_OBJECTS, role, newOwner))
 	defer tmpDb.Close()
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
 	if err != nil && err.(*pq.Error).Code != "42704" {
 		return err
 	}
 
 	// We previously assigned all objects to the operator's role so DROP OWNED BY will drop privileges of role
 	_, err = tmpDb.Exec(fmt.Sprintf(DROP_OWNED_BY, role))
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
 	if err != nil && err.(*pq.Error).Code != "42704" {
 		return err
 	}
 
 	_, err = c.db.Exec(fmt.Sprintf(DROP_ROLE, role))
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
 	if err != nil && err.(*pq.Error).Code != "42704" {
 		return err
 	}


### PR DESCRIPTION
Will fix #44 by deleting all PostgresUser CR linked to a Postgres CR that was deleted.