### PR TITLE
ubi8 base image to solve vurnerabilities

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/postgres-operator \
     USER_UID=1001 \


### PR DESCRIPTION
The operator image based on rhel 7 contains 4 high severity vurnerabilities (aquasec scanner)
I first tried to make a patch on the 0.5.0 version by running the command `microdnf update` this only solves two 2 of high severity vurnerabilities. The other vurnerabilities should be solved in rhel version 8. For this reason I created this pull request.<img width="1261" alt="Screenshot 2021-02-18 at 14 19 55" src="https://user-images.githubusercontent.com/8577732/108362968-b0606b80-71f4-11eb-8976-7c69427d2cc4.png">
<img width="1273" alt="Screenshot 2021-02-18 at 14 20 22" src="https://user-images.githubusercontent.com/8577732/108362979-b2c2c580-71f4-11eb-87d1-b20cf3649160.png">
<img width="1266" alt="Screenshot 2021-02-18 at 14 21 34" src="https://user-images.githubusercontent.com/8577732/108362985-b3f3f280-71f4-11eb-8f1d-b91064748ffd.png">

 

