### PR TITLE
Override DropRole method for Azure

### DIFF
--- a/pkg/postgres/azure.go
+++ b/pkg/postgres/azure.go
@@ -3,6 +3,9 @@ package postgres
 import (
 	"fmt"
 	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/lib/pq"
 )
 
 type azurepg struct {
@@ -46,4 +49,29 @@ func (azpg *azurepg) CreateDB(dbname, role string) error {
 	}
 
 	return azpg.pg.CreateDB(dbname, role)
+}
+
+func (azpg *azurepg) DropRole(role, newOwner, database string, logger logr.Logger) error {
+	// REASSIGN OWNED BY only works if the correct database is selected
+	tmpDb := GetConnection(azpg.user, azpg.pass, azpg.host, database, azpg.args, logger)
+	_, err := tmpDb.Exec(fmt.Sprintf(REASIGN_OBJECTS, role, azpg.GetRoleForLogin(newOwner)))
+	defer tmpDb.Close()
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
+	if err != nil && err.(*pq.Error).Code != "42704" {
+		return err
+	}
+
+	// We previously assigned all objects to the operator's role so DROP OWNED BY will drop privileges of role
+	_, err = tmpDb.Exec(fmt.Sprintf(DROP_OWNED_BY, role))
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
+	if err != nil && err.(*pq.Error).Code != "42704" {
+		return err
+	}
+
+	_, err = azpg.db.Exec(fmt.Sprintf(DROP_ROLE, role))
+	// Check if error exists and if different from "ROLE NOT FOUND" => 42704
+	if err != nil && err.(*pq.Error).Code != "42704" {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Hi all, I'm back with an Azure fix, this time it's related with the `dropOnDelete` option of a `Postgres` object. (Didn't use it until this week)

In Azure Database for PostgreSQL servers the username has the format `<user@servername>`
This username is also passed to the DropRole as the `newOwner`, which is not a valid user for postgres.

This is a copy of the DropRole base method, but the user for `newOwner` is fixed with the `GetRoleForLogin` method.

~~Setting this as draft until I have tested this more on our cluster.~~ Tested and works now!