### PR TITLE
Add optional annotations

### DIFF
--- a/pkg/apis/db/v1alpha1/postgresuser_types.go
+++ b/pkg/apis/db/v1alpha1/postgresuser_types.go
@@ -15,6 +15,8 @@ type PostgresUserSpec struct {
 	SecretName string `json:"secretName"`
 	// +optional
 	Privileges string `json:"privileges"`
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // PostgresUserStatus defines the observed state of PostgresUser

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
+
 	"github.com/movetokube/postgres-operator/pkg/config"
 
 	"github.com/go-logr/logr"
@@ -266,11 +267,14 @@ func (r *ReconcilePostgresUser) newSecretForCR(cr *dbv1alpha1.PostgresUser, role
 	labels := map[string]string{
 		"app": cr.Name,
 	}
+	annotations := cr.Spec.Annotations
+
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Spec.SecretName, cr.Name),
-			Namespace: cr.Namespace,
-			Labels:    labels,
+			Name:        fmt.Sprintf("%s-%s", cr.Spec.SecretName, cr.Name),
+			Namespace:   cr.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Data: map[string][]byte{
 			"POSTGRES_URL":  []byte(pgUserUrl),


### PR DESCRIPTION
### What?

This PR provides the user with the option of passing additional annotations to the secret.

### Why?

Annotations allow the secret to be used with [the pull based replication of the the kubernetes replicator](https://github.com/mittwald/kubernetes-replicator#pull-based-replication).

There are likely to be be many other options.
