### PR TITLE
Fix DropRole being executed on a dropped database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ tags
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 
+### MacOS
+.DS_Store
+
 .idea
 deploy/secret.yaml

--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -35,10 +35,13 @@ func (c *pg) CreateDB(dbname, role string) error {
 }
 
 func (c *pg) CreateSchema(db, role, schema string, logger logr.Logger) error {
-	tmpDb := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	tmpDb, err := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	if err != nil {
+		return err
+	}
 	defer tmpDb.Close()
 
-	_, err := tmpDb.Exec(fmt.Sprintf(CREATE_SCHEMA, schema, role))
+	_, err = tmpDb.Exec(fmt.Sprintf(CREATE_SCHEMA, schema, role))
 	if err != nil {
 		return err
 	}
@@ -58,10 +61,13 @@ func (c *pg) DropDatabase(database string, logger logr.Logger) error {
 }
 
 func (c *pg) CreateExtension(db, extension string, logger logr.Logger) error {
-	tmpDb := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	tmpDb, err := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	if err != nil {
+		return err
+	}
 	defer tmpDb.Close()
 
-	_, err := tmpDb.Exec(fmt.Sprintf(CREATE_EXTENSION, extension))
+	_, err = tmpDb.Exec(fmt.Sprintf(CREATE_EXTENSION, extension))
 	if err != nil {
 		return err
 	}
@@ -69,11 +75,14 @@ func (c *pg) CreateExtension(db, extension string, logger logr.Logger) error {
 }
 
 func (c *pg) SetSchemaPrivileges(db, creator, role, schema, privs string, logger logr.Logger) error {
-	tmpDb := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	tmpDb, err := GetConnection(c.user, c.pass, c.host, db, c.args, logger)
+	if err != nil {
+		return err
+	}
 	defer tmpDb.Close()
 
 	// Grant role usage on schema
-	_, err := tmpDb.Exec(fmt.Sprintf(GRANT_USAGE_SCHEMA, schema, role))
+	_, err = tmpDb.Exec(fmt.Sprintf(GRANT_USAGE_SCHEMA, schema, role))
 	if err != nil {
 		return err
 	}

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -36,8 +36,13 @@ type pg struct {
 }
 
 func NewPG(host, user, password, uri_args, default_database, cloud_type string, logger logr.Logger) (PG, error) {
+	db, err := GetConnection(user, password, host, default_database, uri_args, logger)
+	if err != nil {
+		log.Fatalf("failed to connect to PostgreSQL server: %s", err.Error())
+	}
+	logger.Info("connected to postgres server")
 	postgres := &pg{
-		db:               GetConnection(user, password, host, default_database, uri_args, logger),
+		db:               db,
 		log:              logger,
 		host:             host,
 		user:             user,
@@ -64,15 +69,11 @@ func (c *pg) GetDefaultDatabase() string {
 	return c.default_database
 }
 
-func GetConnection(user, password, host, database, uri_args string, logger logr.Logger) *sql.DB {
+func GetConnection(user, password, host, database, uri_args string, logger logr.Logger) (*sql.DB, error) {
 	db, err := sql.Open("postgres", fmt.Sprintf("postgresql://%s:%s@%s/%s?%s", user, password, host, database, uri_args))
 	if err != nil {
 		log.Fatal(err)
 	}
 	err = db.Ping()
-	if err != nil {
-		log.Fatalf("failed to connect to PostgreSQL server: %s", err.Error())
-	}
-	logger.Info("connected to postgres server")
-	return db
+	return db, err
 }


### PR DESCRIPTION
Hi 👋 

Since using the dropOnDelete flag for the Postgres object, it occurred that the operator was in a crash loop. It was always crashing on the Reconcile loop for PostgresUser because the database was already dropped.
It happens when our ArgoCD deployment deletes the application, and eventually the Postgres object is first removed before the PostgresUser.

I did a small refactor of GetConnection to be able to get the pq error code out of it, and in DropRole I check if the error is the error code for database does not exists.

Not sure if this is the best solution, but I've deployed this fix this week and so far it did not trigger the crash loop anymore.

