### PR TITLE
Add helm chart for the operator installation

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ To install the operator using kustomize, follow the steps below.
     `kustomize build deploy/ | apply -f -`
 
 Alternatively you can install operator using Helm Chart located in the 
-`charts/ext-postgres-operator` subdirectory.
+`charts/ext-postgres-operator` subdirectory. Sample installation commands provided below:
+
+```
+helm repo add ext-postgres-operator https://movetokube.github.io/postgres-operator/
+helm install -n operators ext-postgres-operator  ext-postgres-operator/ext-postgres-operator
+```
+See [values.yaml](charts/ext-postgres-operator/values.yaml) for the possible values to define.
 
 ## CRs
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ data:
   POSTGRES_DEFAULT_DATABASE: cG9zdGdyZXM=
 ```
 
-To install the operator, follow the steps below.
+To install the operator using kustomize, follow the steps below.
 
 1. Configure Postgres credentials for the operator in `deploy/secret.yaml`
 2. Create namespace if needed with\
@@ -67,6 +67,9 @@ To install the operator, follow the steps below.
     `kubectl kustomize deploy/ | apply -f -`\
     or by using [kustomize](https://github.com/kubernetes-sigs/kustomize) directly\
     `kustomize build deploy/ | apply -f -`
+
+Alternatively you can install operator using Helm Chart located in the 
+`charts/ext-postgres-operator` subdirectory.
 
 ## CRs
 

--- a/charts/ext-postgres-operator/.helmignore
+++ b/charts/ext-postgres-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: ext-postgres-operator
+description: A Helm chart for the External Postgres operator
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.1.1"

--- a/charts/ext-postgres-operator/crds/db.movetokube.com_postgres_crd.yaml
+++ b/charts/ext-postgres-operator/crds/db.movetokube.com_postgres_crd.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgres.db.movetokube.com
+spec:
+  group: db.movetokube.com
+  names:
+    kind: Postgres
+    listKind: PostgresList
+    plural: postgres
+    singular: postgres
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Postgres is the Schema for the postgres API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PostgresSpec defines the desired state of Postgres
+            properties:
+              database:
+                type: string
+              dropOnDelete:
+                type: boolean
+              extensions:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              masterRole:
+                type: string
+              schemas:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - database
+            type: object
+          status:
+            description: PostgresStatus defines the observed state of Postgres
+            properties:
+              extensions:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              roles:
+                description: PostgresRoles stores the different group roles for database
+                properties:
+                  owner:
+                    type: string
+                  reader:
+                    type: string
+                  writer:
+                    type: string
+                required:
+                - owner
+                - reader
+                - writer
+                type: object
+              schemas:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              succeeded:
+                type: boolean
+            required:
+            - roles
+            - succeeded
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
+++ b/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresusers.db.movetokube.com
+spec:
+  group: db.movetokube.com
+  names:
+    kind: PostgresUser
+    listKind: PostgresUserList
+    plural: postgresusers
+    singular: postgresuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PostgresUser is the Schema for the postgresusers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PostgresUserSpec defines the desired state of PostgresUser
+            properties:
+              database:
+                type: string
+              privileges:
+                type: string
+              role:
+                type: string
+              secretName:
+                type: string
+            required:
+            - database
+            - role
+            - secretName
+            type: object
+          status:
+            description: PostgresUserStatus defines the observed state of PostgresUser
+            properties:
+              databaseName:
+                type: string
+              postgresGroup:
+                type: string
+              postgresLogin:
+                type: string
+              postgresRole:
+                type: string
+              succeeded:
+                type: boolean
+            required:
+            - databaseName
+            - postgresGroup
+            - postgresLogin
+            - postgresRole
+            - succeeded
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/ext-postgres-operator/templates/_helpers.tpl
+++ b/charts/ext-postgres-operator/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "chart.selectorLabelsDev" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-dev
+app.kubernetes.io/instance: {{ .Release.Name }}-dev
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+          - postgres-operator
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "chart.fullname" . }}
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: {{ include "chart.fullname" . }}

--- a/charts/ext-postgres-operator/templates/role.yaml
+++ b/charts/ext-postgres-operator/templates/role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resourceNames:
+  - ext-postgres-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - db.movetokube.com
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/charts/ext-postgres-operator/templates/role_binding.yaml
+++ b/charts/ext-postgres-operator/templates/role_binding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "chart.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/ext-postgres-operator/templates/secret.yaml
+++ b/charts/ext-postgres-operator/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ .Release.namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+type: Opaque
+data:
+  POSTGRES_HOST: {{ .Values.postgres.host | b64enc | quote }}
+  POSTGRES_USER: {{ .Values.postgres.user | b64enc | quote }}
+  POSTGRES_PASS: {{ .Values.postgres.password | b64enc | quote }}
+  POSTGRES_URI_ARGS: {{ .Values.postgres.uri_args | b64enc | quote }}
+  POSTGRES_CLOUD_PROVIDER: {{ .Values.postgres.cloud_provider | b64enc | quote }}
+  POSTGRES_DEFAULT_DATABASE: {{ .Values.postgres.default_database | b64enc | quote }}

--- a/charts/ext-postgres-operator/templates/secret.yaml
+++ b/charts/ext-postgres-operator/templates/secret.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
   name: {{ include "chart.fullname" . }}
   namespace: {{ .Release.namespace }}
   labels:

--- a/charts/ext-postgres-operator/templates/serviceaccount.yaml
+++ b/charts/ext-postgres-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -1,0 +1,51 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: movetokube/postgres-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+postgres:
+  # postgres hostname
+  host: "localhost"
+  # postgres admin user and password
+  user: "admin"
+  password: "password"
+  # additional connection args to pg driver
+  uri_args: ""
+  # postgres cloud provider, could be AWS, Azure, GCP or empty (default)
+  cloud_provider: ""
+  # default database to use
+  default_database: "postgres"


### PR DESCRIPTION
This PR is to add helm chart for the Postgres Operator installation. I think it could be more convenient compared to k8s kustomize way for many usecases. Please let me know if you want any changes or parameters to be added.

## Changes in the PR:

- Helm added
- Added CI action to host helm using github pages
