### PR TITLE
add servicemonitor permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -38,3 +38,9 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - '*'


### PR DESCRIPTION
lets the operator create a servicemonitor in its namespace