### PR TITLE
[helm] Add volume management, custom labels, environment variables and custom existing secret

### DIFF
--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -61,3 +61,7 @@ spec:
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}
       {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -32,7 +32,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
+                {{- if .Values.existingSecret }}
+                name: {{ .Values.existingSecret }}
+                {{- else }}
                 name: {{ include "chart.fullname" . }}
+                {{- end }}
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace | default "" }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -42,3 +42,11 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: {{ include "chart.fullname" . }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.volumes }}
+      volumes:
+        {{- toYaml .Values.volumes | nindent 8 }}
+      {{- end }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -18,7 +18,9 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       securityContext:
@@ -47,6 +49,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: {{ include "chart.fullname" . }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
     spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       securityContext:

--- a/charts/ext-postgres-operator/templates/secret.yaml
+++ b/charts/ext-postgres-operator/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- if (not .Values.existingSecret) }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +17,4 @@ data:
   POSTGRES_URI_ARGS: {{ .Values.postgres.uri_args | b64enc | quote }}
   POSTGRES_CLOUD_PROVIDER: {{ .Values.postgres.cloud_provider | b64enc | quote }}
   POSTGRES_DEFAULT_DATABASE: {{ .Values.postgres.default_database | b64enc | quote }}
+{{- end }}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -24,6 +24,7 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Additionnal labels to add to the pod.
 podLabels: {}
 
 podSecurityContext: {}
@@ -58,12 +59,17 @@ postgres:
   # default database to use
   default_database: "postgres"
 
+# Volumes to add to the pod.
 volumes: []
 
+# Volumes to mount onto the pod.
 volumeMounts: []
 
+# Existing secret where values to connect to Postgres are defined.
+# If not set a new secret will be created, filled with information under the postgres key above.
 existingSecret: ""
 
+# Additionnal environment variables to add to the pod (map of key / value)
 env: {}
 
 nodeSelector: {}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -55,3 +55,7 @@ postgres:
   cloud_provider: ""
   # default database to use
   default_database: "postgres"
+
+volumes: []
+
+volumeMounts: []

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -63,3 +63,5 @@ volumes: []
 volumeMounts: []
 
 existingSecret: ""
+
+env: {}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -65,3 +65,7 @@ volumeMounts: []
 existingSecret: ""
 
 env: {}
+
+nodeSelector: {}
+
+tolerations: []

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -24,6 +24,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -59,3 +59,5 @@ postgres:
 volumes: []
 
 volumeMounts: []
+
+existingSecret: ""


### PR DESCRIPTION
Hello, :wave:

Thanks for your work on this operator, it's very useful!
We installed it on our EKS cluster using Helm after some tweaking to make it work with AWS-flavored Kubernetes components (most notably the CSI driver for AWS secrets and the CNI), here they are in this PR.

## Context

- When using a secrets CSI driver such as AWS CSI driver, we want to be able to mount volumes with secrets coming from a `SecretProviderClass` (see [documentation](https://aws.amazon.com/blogs/security/how-to-use-aws-secrets-configuration-provider-with-kubernetes-secrets-store-csi-driver/)), which will create a secret with some needed keys.
- When using AWS `SecurityGroupPolicy`, we want to be able to add custom labels onto our pods since it applies to pods with a `matchLabels` (see [documentation](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html))

## Changelog

- Add `volumes` and `volumeMounts` in Helm chart, to declare and mount volumes on the pod.
- Add `podLabels` to add custom labels on the pod.
- Add `env` to specify additional environment variables injected in pod.
- Add `existingSecret` to specify an already existing secret where the operator may fetch its environment variables (this will not create a new secret).
- Add `tolerations` and `nodeSelector` to make it possible to manage more precisely where the pods are scheduled.

I am unsure as to how to bump the version.

Let me know if there is anything incorrect, I'll be happy to update it.

Thanks!