### PR TITLE
Correct the Database Connection

### DIFF
--- a/pkg/postgres/database.go
+++ b/pkg/postgres/database.go
@@ -59,7 +59,7 @@ func (c *pg) CreateSchema(db, role, schema string, logger logr.Logger) error {
 	// Set the schema owner in a separate step, because AWS RDS breaks if
 	// you try to create a schema and set the owner in a single command.
 	//   See: https://github.com/movetokube/postgres-operator/issues/91
-	_, err = c.db.Exec(fmt.Sprintf(ALTER_SCHEMA_OWNER, schema, role))
+	_, err = tmpDb.Exec(fmt.Sprintf(ALTER_SCHEMA_OWNER, schema, role))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This line accidentally used the object database connection rather than the locally created database connection.

Correcting this should hopefully fix the failing Schema creation issue.