### PR TITLE
Add support for multi platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
           push: true
           tags:
             ghcr.io/brpaz/postgres-operator:latest
-            ghcr.io/brpaz/postgres-operator:${DOCKER_TAG}
-            brpaz/postgres-operator:${DOCKER_TAG}
+            ghcr.io/brpaz/postgres-operator:${{ env.DOCKER_TAG }}
+            brpaz/postgres-operator:${{ env.DOCKER_TAG }}
             brpaz/postgres-operator:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,7 +43,7 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile.dist
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             ghcr.io/brpaz/postgres-operator:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags:
+          tags: |
             ghcr.io/brpaz/postgres-operator:latest
             ghcr.io/brpaz/postgres-operator:${{ env.DOCKER_TAG }}
             brpaz/postgres-operator:${{ env.DOCKER_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,26 +6,43 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+
       - name: Generate Docker Tag
         run: |
           echo ${{ github.ref }} | cut -d '/' -f 3 > DOCKER_TAG
-      - name: Build and push container image
-        run: |
-          docker build --file build/Dockerfile.dist --tag ghcr.io/movetokube/postgres-operator:$(cat DOCKER_TAG) --tag movetokube/postgres-operator:$(cat DOCKER_TAG) .
-          docker tag ghcr.io/movetokube/postgres-operator:$(cat DOCKER_TAG) ghcr.io/movetokube/postgres-operator:latest
-          docker tag movetokube/postgres-operator:$(cat DOCKER_TAG) movetokube/postgres-operator:latest
-         
-          docker login ghcr.io --username USERNAME --password ${{ secrets.GITHUB_TOKEN }}
-          docker push ghcr.io/movetokube/postgres-operator:$(cat DOCKER_TAG)
-          docker push ghcr.io/movetokube/postgres-operator:latest
-          
-          docker login --username ${{ secrets.DOCKER_USER }} --password ${{ secrets.DOCKER_TOKEN }}
-          docker push movetokube/postgres-operator:$(cat DOCKER_TAG)
-          docker push movetokube/postgres-operator:latest
+          # Set docker tag in github env
+          echo "DOCKER_TAG=$(cat DOCKER_TAG)" >> $GITHUB_ENV
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags:
+            ghcr.io/brpaz/postgres-operator:latest
+            ghcr.io/brpaz/postgres-operator:${DOCKER_TAG}
+            brpaz/postgres-operator:${DOCKER_TAG}
+            brpaz/postgres-operator:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Generate Docker Tag
         run: |
           echo ${{ github.ref }} | cut -d '/' -f 3 > DOCKER_TAG
-          # Set docker tag in github env
           echo "DOCKER_TAG=$(cat DOCKER_TAG)" >> $GITHUB_ENV
 
       - name: Set up QEMU
@@ -46,7 +45,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/brpaz/postgres-operator:latest
-            ghcr.io/brpaz/postgres-operator:${{ env.DOCKER_TAG }}
-            brpaz/postgres-operator:${{ env.DOCKER_TAG }}
-            brpaz/postgres-operator:latest
+            ghcr.io/movetokube/postgres-operator:latest
+            ghcr.io/movetokube/postgres-operator:${{ env.DOCKER_TAG }}
+            movetokube/postgres-operator:${{ env.DOCKER_TAG }}
+            movetokube/postgres-operator:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile.dist
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/brpaz/postgres-operator:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./build/Dockerfile.dist
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/build/Dockerfile.dist
+++ b/build/Dockerfile.dist
@@ -20,6 +20,8 @@ RUN --mount=target=. \
 
 FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+ARG TARGETPLATFORM
+
 ENV OPERATOR=/usr/local/bin/postgres-operator \
     USER_UID=1001 \
     USER_NAME=postgres-operator

--- a/build/Dockerfile.dist
+++ b/build/Dockerfile.dist
@@ -20,8 +20,6 @@ RUN --mount=target=. \
 
 FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-ARG TARGETPLATFORM
-
 ENV OPERATOR=/usr/local/bin/postgres-operator \
     USER_UID=1001 \
     USER_NAME=postgres-operator

--- a/build/Dockerfile.dist
+++ b/build/Dockerfile.dist
@@ -1,12 +1,24 @@
-FROM golang:1.18-stretch
+# syntax=docker/dockerfile:1
+FROM --platform=${BUILDPLATFORM} golang:1.18-stretch AS build
 
-COPY . /go/src/github.com/movetokube/postgres-operator
-WORKDIR /go/src/github.com/movetokube/postgres-operator/cmd/manager
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /usr/local/bin/postgres-operator
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 
+COPY . .
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /usr/local/bin/postgres-operator cmd/manager/main.go
+
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/postgres-operator \
     USER_UID=1001 \
@@ -21,4 +33,3 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}
-


### PR DESCRIPTION

## Context

ARM-based platforms are getting more and more popular, and most well know projects and helm charts already support ARM architectures. (Ex: Prometheus, Grafana, Postgres, Cert Manager, etc). The only thing that I need in my Kubernetes cluster that was missing support for ARM was this operator.

This PR aims to fix that.  Closes #123 

## Changes

- **Dockerfile** -  Add support for multi-platform builds following recommendations from [this](https://docs.docker.com/build/building/multi-platform/) and [this](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/).  Also refactored a bit the Dockerfile with cache support, which is important to optimize the build time, when building for multiple platforms.
- **GitHub Actions** - Refactored the release workflow to leverage, official docker GitHub actions, which makes building images for multi-platform easier. Reference: https://docs.docker.com/build/ci/github-actions/multi-platform/

