### PR TITLE
Allow read database credentials from existing secret created by other operators

### DIFF
--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -47,6 +47,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresCredsExistingSecrets.username.secretName }}
+                  key: {{ .Values.postgresCredsExistingSecrets.username.secretKey }}
+            - name: POSTGRES_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresCredsExistingSecrets.password.secretName }}
+                  key: {{ .Values.postgresCredsExistingSecrets.password.secretKey }}
             - name: OPERATOR_NAME
               value: {{ include "chart.fullname" . }}
             {{- range $key, $value := .Values.env }}

--- a/charts/ext-postgres-operator/templates/secret.yaml
+++ b/charts/ext-postgres-operator/templates/secret.yaml
@@ -12,8 +12,10 @@ metadata:
 type: Opaque
 data:
   POSTGRES_HOST: {{ .Values.postgres.host | b64enc | quote }}
+  {{- if (not .Values.postgresCredsExistingSecrets) }}
   POSTGRES_USER: {{ .Values.postgres.user | b64enc | quote }}
   POSTGRES_PASS: {{ .Values.postgres.password | b64enc | quote }}
+  {{- end }}
   POSTGRES_URI_ARGS: {{ .Values.postgres.uri_args | b64enc | quote }}
   POSTGRES_CLOUD_PROVIDER: {{ .Values.postgres.cloud_provider | b64enc | quote }}
   POSTGRES_DEFAULT_DATABASE: {{ .Values.postgres.default_database | b64enc | quote }}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -69,6 +69,14 @@ volumeMounts: []
 # If not set a new secret will be created, filled with information under the postgres key above.
 existingSecret: ""
 
+postgresCredsExistingSecrets:
+  username:
+    secretName: "" 
+    secretKey: ""
+  password:
+    secretName: "" 
+    secretKey: ""
+
 # Additionnal environment variables to add to the pod (map of key / value)
 env: {}
 


### PR DESCRIPTION
### Context
Some prostgresql operators (like zalando/postgres-operator) automatically create a secret containing username and password randomly generated) for the postgresql cluster. 

I added the possibility to use the secret created by these operators by specifying the name of the secret and the key in this operator.