### PR TITLE
allow keeping secret name as defined in user spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ These environment variables are embedded in [deploy/operator.yaml](deploy/operat
 
 `POSTGRES_INSTANCE` is only available since version 1.2.0
 
+> While using `KEEP_SECRET_NAME` could be a convenient way to define secrets with predictable and explicit names, 
+> the default logic reduces risk of operator from entering the endless reconcile loop as secret is very unlikely to exist. 
+>
+> The administrator should ensure that the `SecretName` does not collide with other secrets in the same namespace. 
+> If the secret already exists, the operator will never stop reconciling the CR until either offending secret is deleted 
+> or CR is deleted or updated with another SecretName
+
 ## Installation
 
 This operator requires a Kubernetes Secret to be created in the same namespace as operator itself.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These environment variables are embedded in [deploy/operator.yaml](deploy/operat
 * `WATCH_NAMESPACE` - which namespace to watch. Defaults to empty string for all namespaces
 * `OPERATOR_NAME` - name of the operator, defaults to `ext-postgres-operator` 
 * `POSTGRES_INSTANCE` - identity of operator, this matched with `postgres.db.movetokube.com/instance` in CRs. Default is empty
+* `KEEP_SECRET_NAME` - use secret name as provided by user (disabled by default)
 
 `POSTGRES_INSTANCE` is only available since version 1.2.0
 
@@ -167,7 +168,7 @@ spec:
     foo: "bar"
 ```
 
-This creates a user role `username-<hash>` and grants role `test-db-group`, `test-db-writer` or `test-db-reader` depending on `privileges` property. Its credentials are put in secret `my-secret-my-db-user`.
+This creates a user role `username-<hash>` and grants role `test-db-group`, `test-db-writer` or `test-db-reader` depending on `privileges` property. Its credentials are put in secret `my-secret-my-db-user` (unless `KEEP_SECRET_NAME` is enabled).
 
 `PostgresUser` needs to reference a `Postgres` in the same namespace.
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
+            - name: KEEP_SECRET_NAME
+              value: "false"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/movetokube/postgres-operator/pkg/utils"
@@ -15,6 +16,7 @@ type cfg struct {
 	PostgresDefaultDb string
 	CloudProvider     string
 	AnnotationFilter  string
+	KeepSecretName    bool
 }
 
 var doOnce sync.Once
@@ -30,6 +32,9 @@ func Get() *cfg {
 		config.PostgresDefaultDb = utils.GetEnv("POSTGRES_DEFAULT_DATABASE")
 		config.CloudProvider = utils.GetEnv("POSTGRES_CLOUD_PROVIDER")
 		config.AnnotationFilter = utils.GetEnv("POSTGRES_INSTANCE")
+		if value, err := strconv.ParseBool(utils.GetEnv("KEEP_SECRET_NAME")); err == nil {
+			config.KeepSecretName = value
+		}
 	})
 	return config
 }


### PR DESCRIPTION
Allow keeping secret name as defined in user spec while keeping current behavior by-default (ie: backward compatible).

PR adds new boolean environment variable `KEEP_SECRET_NAME` (disabled by default) which instructs operator create secret with name exactly as defined in `PostgresUserSpec`.

The main motivation is to increase transparency for operations team: understand which secret will be created without having deep knowledge of the operator code ([principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)).

This is "opt-in" flag and doesn't require any configuration change for existing users to keep current behavior.