### PR TITLE
Add the 'annotations' field in the PostgresUser CRD

### DIFF
--- a/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
+++ b/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
@@ -39,6 +39,10 @@ spec:
                 type: string
               secretName:
                 type: string
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
             required:
             - database
             - role


### PR DESCRIPTION
The 'annotations' field was missing from the PostgresUser CRD, disabling the feature to add annotations to the secret