### PR TITLE
Ensure chart env values are strings/quoted

### DIFF
--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -51,7 +51,7 @@ spec:
               value: {{ include "chart.fullname" . }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:


### PR DESCRIPTION
Trying to use `KEEP_SECRET_NAME` the values were interpolated as boolean.

values.yaml
```yaml
env:
  KEEP_SECRET_NAME: "true"
```

Or `helm template . --set "env.KEEP_SECRET_NAME=true"`

Or `helm_release` terraform provider 
```hcl
resource "helm_release" "postgres_controller" {
 ...
  set {
    name  = "env.KEEP_SECRET_NAME"
    type  = "string"
    value = "true"
  }
  ...
}
``` 

**Desired:**

```yaml
containers:
  env:
    - name: KEEP_SECRET_NAME
      value: "true"
```

**Actual:**

```yaml
containers:
  env:
    - name: KEEP_SECRET_NAME
      value: true
```

```
json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

Environment values must always be of type string