### PR TITLE
fix(postgresuser): return k8s client error before annotations

### DIFF
--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -325,11 +325,11 @@ func (r *ReconcilePostgresUser) getPostgresCR(instance *dbv1alpha1.PostgresUser)
 	database := dbv1alpha1.Postgres{}
 	err := r.client.Get(context.TODO(),
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Database}, &database)
-	if !utils.MatchesInstanceAnnotation(database.Annotations, r.instanceFilter) {
-		err = fmt.Errorf("database \"%s\" is not managed by this operator", database.Name)
+	if err != nil {
 		return nil, err
 	}
-	if err != nil {
+	if !utils.MatchesInstanceAnnotation(database.Annotations, r.instanceFilter) {
+		err = fmt.Errorf("database \"%s\" is not managed by this operator", database.Name)
 		return nil, err
 	}
 	if !database.Status.Succeeded {


### PR DESCRIPTION
In the GetPostgresCR function, we should return the k8s client error before checking the annotations. If not, deleting a Postgres resource will cause the linked PostgresUsers to enter an infinite reconciliation loop as the CR NotFound error will never be returned to the Reconcile function.

This PR should fix #118.