### PR TITLE
fix(aws): remove role even if database doesn't exists

### DIFF
--- a/pkg/postgres/aws.go
+++ b/pkg/postgres/aws.go
@@ -70,6 +70,12 @@ func (c *awspg) DropRole(role, newOwner, database string, logger logr.Logger) er
 		if err.(*pq.Error).Code == "42704" {
 			// The group role does not exist, no point of granting roles
 			logger.Info(fmt.Sprintf("not granting %s to %s as %s does not exist", role, newOwner, newOwner))
+
+			_, err = c.pg.db.Exec(fmt.Sprintf(DROP_ROLE, role))
+			if err != nil && err.(*pq.Error).Code != "42704" {
+				return err
+			}
+			logger.Info(fmt.Sprintf("role \"%s\" has been dropped", role))
 			return nil
 		}
 		return err


### PR DESCRIPTION
I observed that the role created by the PostgresUser is not properly cleaned up if the database has been removed before the PostgresUser.

As far I understand, if the group `mydb-group` doesn't exists, the PostgresUser's role should be dropped directly. Is that right?