### PR TITLE
fix(chart): add missing renaming from template to secretTemplate

### DIFF
--- a/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
+++ b/charts/ext-postgres-operator/crds/db.movetokube.com_postgresusers_crd.yaml
@@ -43,7 +43,7 @@ spec:
                 type: string
               secretName:
                 type: string
-              template:
+              secretTemplate:
                 additionalProperties:
                   type: string
                 type: object


### PR DESCRIPTION
The template was renamed as secretTemplate in https://github.com/movetokube/postgres-operator/pull/143, but this update needed to be added to the helm chart.