### PR TITLE
Add annotations to operator deployment

### DIFF
--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -22,6 +22,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 # Additionnal labels to add to the pod.


### PR DESCRIPTION
Hi! 

This PR adds annotations configuration for the operator `Deployment` resource.

Main use case is that when using an externally rotating secret (i.e. Managed secrets in AWS RDS that rotate every 7 days) there is the need to make the operator read the new secret. For this I use the [Reloader](https://github.com/stakater/Reloader), which requires you to annotate the deployment with the secret that it should be monitoring to decide if the deployment needs to be restarted.

I have followed the same pattern as `podAnnotations` for consistentcy.

I am not bumping any version, but let me know if I should bump the chart version or it is something that you do when releasing.

Thanks for all the good work in this operator!
