### PR TITLE
Add secure string generator for Password generator

### DIFF
--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -162,7 +162,11 @@ func (r *ReconcilePostgresUser) Reconcile(request reconcile.Request) (reconcile.
 
 	// Creation logic
 	var role, login string
-	password := utils.GetRandomString(15)
+	password, err := utils.GetSecureRandomString(15)
+
+	if err != nil {
+		return r.requeue(instance, err)
+	}
 
 	if instance.Status.PostgresRole == "" {
 		// We need to get the Postgres CR to get the group role name
@@ -172,6 +176,7 @@ func (r *ReconcilePostgresUser) Reconcile(request reconcile.Request) (reconcile.
 		}
 		// Create user role
 		suffix := utils.GetRandomString(6)
+		
 		role = fmt.Sprintf("%s-%s", instance.Spec.Role, suffix)
 		login, err = r.pg.CreateUserRole(role, password)
 		if err != nil {

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -176,7 +176,6 @@ func (r *ReconcilePostgresUser) Reconcile(request reconcile.Request) (reconcile.
 		}
 		// Create user role
 		suffix := utils.GetRandomString(6)
-		
 		role = fmt.Sprintf("%s-%s", instance.Spec.Role, suffix)
 		login, err = r.pg.CreateUserRole(role, password)
 		if err != nil {

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -2,6 +2,7 @@ package utils
 
 import cryptorand "crypto/rand"
 import "math/rand"
+import "math/big"
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
 

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -1,5 +1,6 @@
 package utils
 
+import cryptorand "crypto/rand"
 import "math/rand"
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
@@ -10,4 +11,18 @@ func GetRandomString(length int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// If the secure random number generator malfunctions it will return an error
+func GetSecureRandomString(length int) (string, error) {
+	b := make([]rune, length)
+	for i := 0; i < length; i++ {
+		num, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(len(letterRunes))))
+		if err != nil {
+			return "", err
+		}
+		b[i] = letterRunes[num.Int64()]
+	}
+
+	return string(b), nil
 }


### PR DESCRIPTION
Hi,

I have had some occurrences where a service in different environments, newly bootstrapped, was getting the same password for both environments (dev and staging). I am not very proficient in Go, but I assume it has to do with the usage of the math random function without a seed. In any case I have been reading and it seems to be recommended the usage of `crypto/rand` for password generation (and also the usage of Seed is deprecated)

As I said I am not an expert Go programmer, but I have tried to add a new function following the same structure of the current one but with the usage of the `crypto/rand` library. I think it likely that this is not a totally secure implementation, as while investigating how to do this I have seen implementations that go in a lot more detail, but I thought that this was a good enough step in this direction. 

One thing to note is that apparently the password generation can fail if the secure number generation has issues, so now when creating the password a new error has to be handled. I have chose for re queuing the instance, as it is done in other errors, though I have to say I am not certain if this would be a recoverable error.

Resources that I looked into for this implementation:
https://pkg.go.dev/crypto/rand
https://github.com/golang/go/issues/56319
https://stackoverflow.com/a/32351471
https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
https://gist.github.com/denisbrodbeck/635a644089868a51eccd6ae22b2eb800