### PR TITLE
fix: Use Cascading Deletion in a Cluster

### DIFF
--- a/pkg/controller/postgres/postgres_controller.go
+++ b/pkg/controller/postgres/postgres_controller.go
@@ -254,7 +254,7 @@ func (r *ReconcilePostgres) Reconcile(request reconcile.Request) (_ reconcile.Re
 func (r *ReconcilePostgres) addFinalizer(reqLogger logr.Logger, m *dbv1alpha1.Postgres) error {
 	if len(m.GetFinalizers()) < 1 && m.GetDeletionTimestamp() == nil {
 		reqLogger.Info("adding Finalizer for Postgres")
-		m.SetFinalizers([]string{"finalizer.db.movetokube.com"})
+		m.SetFinalizers([]string{"foregroundDeletion"})
 	}
 	return nil
 }

--- a/pkg/controller/postgres/postgres_controller_test.go
+++ b/pkg/controller/postgres/postgres_controller_test.go
@@ -85,7 +85,7 @@ var _ = Describe("ReconcilePostgres", func() {
 					Name:              name,
 					Namespace:         namespace,
 					DeletionTimestamp: &now,
-					Finalizers:        []string{"finalizer.db.movetokube.com"},
+					Finalizers:        []string{"foregroundDeletion"},
 				},
 				Spec: v1alpha1.PostgresSpec{
 					Database: name,
@@ -200,7 +200,7 @@ var _ = Describe("ReconcilePostgres", func() {
 					foundPostgres := &v1alpha1.Postgres{}
 					err = cl.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, foundPostgres)
 					Expect(err).To(BeNil())
-					Expect(foundPostgres.GetFinalizers()[0]).To(Equal("finalizer.db.movetokube.com"))
+					Expect(foundPostgres.GetFinalizers()[0]).To(Equal("foregroundDeletion"))
 				})
 
 			})
@@ -401,7 +401,7 @@ var _ = Describe("ReconcilePostgres", func() {
 			})
 
 			It("should set a finalizer", func() {
-				expectedFinalizer := "finalizer.db.movetokube.com"
+				expectedFinalizer := "foregroundDeletion"
 				// Call Reconcile
 				_, err := rp.Reconcile(req)
 				// No error should be returned
@@ -707,7 +707,7 @@ var _ = Describe("ReconcilePostgres", func() {
 					// Expected method calls
 					// customers schema errors
 					pg.EXPECT().CreateSchema(name, name+"-group", "customers", gomock.Any()).Return(fmt.Errorf("Could not create schema")).Times(1)
-					pg.EXPECT().SetSchemaPrivileges(name, name+"-group", gomock.Any(), "customers", gomock.Any(), gomock.Any() ,gomock.Any()).Return(nil).Times(0)
+					pg.EXPECT().SetSchemaPrivileges(name, name+"-group", gomock.Any(), "customers", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 					// stores schema
 					pg.EXPECT().CreateSchema(name, name+"-group", "stores", gomock.Any()).Return(nil).Times(1)
 					pg.EXPECT().SetSchemaPrivileges(name, name+"-group", name+"-reader", "stores", gomock.Any(), false, gomock.Any()).Return(nil).Times(1)

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -267,7 +267,7 @@ func (r *ReconcilePostgresUser) Reconcile(request reconcile.Request) (reconcile.
 func (r *ReconcilePostgresUser) addFinalizer(reqLogger logr.Logger, m *dbv1alpha1.PostgresUser) error {
 	if len(m.GetFinalizers()) < 1 && m.GetDeletionTimestamp() == nil {
 		reqLogger.Info("adding Finalizer for Postgres")
-		m.SetFinalizers([]string{"finalizer.db.movetokube.com"})
+		m.SetFinalizers([]string{"foregroundDeletion"})
 
 		// Update CR
 		err := r.client.Update(context.TODO(), m)


### PR DESCRIPTION
Due to custom finalizers, a [situation](https://github.com/movetokube/postgres-operator/issues/94) arises when the operator deployment was removed at a time when the CR was not removed.

So let's let Kubernetes remove it all