### PR TITLE
feat(postgresusercr): allows usernames to be created with suffix with…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ unit-test:
 unit-test-coverage: unit-test
 	go tool cover -html coverage.out
 linux-docker:
-	@docker run -ti -v $(PWD):/work golang:1.13.15-stretch /bin/bash
+	@docker run -ti -v $(PWD):/work golang:1.22-alpine /bin/bash
 linux-build:
 	@GOBIN=/work/bin GO111MODULE=on GOOS=linux GOARC=x86_64 go build --mod=vendor  -o operator github.com/movetokube/postgres-operator/cmd/manager
 docker-build:
-	docker run -ti -v $(PWD):/work -w /work golang:1.13.15-stretch make linux-build
+	docker run -ti -v $(PWD):/work -w /work golang:1.22-alpine make linux-build

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ unit-test:
 unit-test-coverage: unit-test
 	go tool cover -html coverage.out
 linux-docker:
-	@docker run -ti -v $(PWD):/work golang:1.22-alpine /bin/bash
+	@docker run -ti -v $(PWD):/work golang:1.22-bullseye /bin/bash
 linux-build:
 	@GOBIN=/work/bin GO111MODULE=on GOOS=linux GOARC=x86_64 go build --mod=vendor  -o operator github.com/movetokube/postgres-operator/cmd/manager
 docker-build:
-	docker run -ti -v $(PWD):/work -w /work golang:1.22-alpine make linux-build
+	docker run -ti -v $(PWD):/work -w /work golang:1.22-bullseye make linux-build

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ spec:
   role: username
   database: my-db       # This references the Postgres CR
   secretName: my-secret
+  userName: myuser      # Optional, to have roles/usernames with static names.
   privileges: OWNER     # Can be OWNER/READ/WRITE
   annotations:          # Annotations to be propagated to the secrets metadata section (optional)
     foo: "bar"

--- a/build/Dockerfile.dist
+++ b/build/Dockerfile.dist
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=${BUILDPLATFORM} golang:1.18-stretch AS build
+FROM --platform=${BUILDPLATFORM} golang:1.22-bullseye AS build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/deploy/crds/db.movetokube.com_postgresusers_crd.yaml
+++ b/deploy/crds/db.movetokube.com_postgresusers_crd.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               secretName:
                 type: string
+              userName:
+                type: string
               secretTemplate:
                 additionalProperties:
                   type: string

--- a/deploy/crds/db_v1alpha1_postgresuser_cr.yaml
+++ b/deploy/crds/db_v1alpha1_postgresuser_cr.yaml
@@ -7,4 +7,5 @@ spec:
   role: username
   database: my-db # This references the Postgres CR
   secretName: my-secret
+  userName: myuser # If specified, the operator will create a role with this name otherwise the role value with a suffix
   privileges: OWNER # Can be OWNER/READ/WRITE

--- a/pkg/apis/db/v1alpha1/postgresuser_types.go
+++ b/pkg/apis/db/v1alpha1/postgresuser_types.go
@@ -13,6 +13,7 @@ type PostgresUserSpec struct {
 	Role       string `json:"role"`
 	Database   string `json:"database"`
 	SecretName string `json:"secretName"`
+	UserName   string `json:"userName,omitempty"`
 	// +optional
 	SecretTemplate map[string]string `json:"secretTemplate,omitempty"` // key-value, where key is secret field, value is go template
 	// +optional

--- a/pkg/controller/postgresuser/postgresuser_controller.go
+++ b/pkg/controller/postgresuser/postgresuser_controller.go
@@ -175,8 +175,15 @@ func (r *ReconcilePostgresUser) Reconcile(request reconcile.Request) (reconcile.
 			return r.requeue(instance, errors.NewInternalError(err))
 		}
 		// Create user role
-		suffix := utils.GetRandomString(6)
-		role = fmt.Sprintf("%s-%s", instance.Spec.Role, suffix)
+		role := ""
+		// Checks if the userName is provided to create users without suffix
+		if instance.Spec.UserName == "" {
+			suffix := utils.GetRandomString(6)
+			role = fmt.Sprintf("%s-%s", instance.Spec.Role, suffix)
+		} else {
+			role = instance.Spec.UserName
+		}
+
 		login, err = r.pg.CreateUserRole(role, password)
 		if err != nil {
 			return r.requeue(instance, errors.NewInternalError(err))


### PR DESCRIPTION
… a userName parameter

This PR will:
- Enable the CR to accept a parameter named `userName` which can be used to create users/roles without a suffix. If the parameter is empty, the rolename with suffix is created
- Updates the docker image tags used for building

fix #153