### PR TITLE
Minor fixes to the Helm chart

### DIFF
--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "chart.selectorLabels" . | nindent 6 }}

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -54,6 +54,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 image:
   repository: ghcr.io/movetokube/postgres-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Hi,
this MR:
- add the possibility to set revisionHistoryLimit in the deployment, but keeping the default value to kubernete's default, thus making this change transparent
- add missing "resources" block into the deployment (defined in values.yaml but missing in the deployment)

Thanks!