### PR TITLE
Fix empty HOST field in the generated secret

### DIFF
--- a/internal/controller/postgresuser_controller.go
+++ b/internal/controller/postgresuser_controller.go
@@ -39,6 +39,7 @@ func NewPostgresUserReconciler(mgr manager.Manager, cfg *config.Cfg, pg postgres
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		pg:             pg,
+		pgHost:         cfg.PostgresHost,
 		instanceFilter: cfg.AnnotationFilter,
 		keepSecretName: cfg.KeepSecretName,
 	}

--- a/internal/controller/postgresuser_controller_test.go
+++ b/internal/controller/postgresuser_controller_test.go
@@ -316,9 +316,14 @@ var _ = Describe("PostgresUser Controller", func() {
 				foundSecret := &corev1.Secret{}
 				err = cl.Get(ctx, types.NamespacedName{Name: secretName + "-" + name, Namespace: namespace}, foundSecret)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(foundSecret.Data).To(HaveKey("ROLE"))
+				Expect(foundSecret.Data).To(HaveKey("DATABASE_NAME"))
+				Expect(foundSecret.Data).To(HaveKey("HOST"))
+				Expect(foundSecret.Data).To(HaveKey("LOGIN"))
 				Expect(foundSecret.Data).To(HaveKey("PASSWORD"))
+				Expect(foundSecret.Data).To(HaveKey("POSTGRES_DOTNET_URL"))
+				Expect(foundSecret.Data).To(HaveKey("POSTGRES_JDBC_URL"))
 				Expect(foundSecret.Data).To(HaveKey("POSTGRES_URL"))
+				Expect(foundSecret.Data).To(HaveKey("ROLE"))
 			})
 
 			It("should fail if the database does not exist", func() {


### PR DESCRIPTION
Found a bug that the HOST entry was empty in the generated secret.
I was unable to make a test that fails on this however, but I think not a lot of changes will happen anymore on this code. (We don't use the initializer method in the tests)