### PR TITLE
Fix Helm Chart release workflow

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - charts/*
+      - charts/**
 
 jobs:
   release:

--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -7,5 +7,6 @@ description: |
   helm upgrade --install -n operators ext-postgres-operator  ext-postgres-operator/ext-postgres-operator
 
 type: application
+
 version: 2.0.0
 appVersion: "2.0.0"


### PR DESCRIPTION
- Fixed workflow that did not trigger when the chart was updated
- Made a dummy change so it will release 2.0.0 helm chart properly now