### PR TITLE
feat: Enable liveness and readiness Probes in helm chart

### DIFF
--- a/charts/ext-postgres-operator/Chart.yaml
+++ b/charts/ext-postgres-operator/Chart.yaml
@@ -8,5 +8,5 @@ description: |
 
 type: application
 
-version: 2.0.1
+version: 2.1.0
 appVersion: "2.0.0"

--- a/charts/ext-postgres-operator/templates/operator.yaml
+++ b/charts/ext-postgres-operator/templates/operator.yaml
@@ -56,6 +56,14 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ext-postgres-operator/values.yaml
+++ b/charts/ext-postgres-operator/values.yaml
@@ -58,6 +58,21 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+
+# Define liveness and readiness Probes
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
 # Which namespace to watch in kubernetes, empty string means all namespaces
 watchNamespace: ""
 


### PR DESCRIPTION
Enable liveness and readiness Probes for the operator, in the helm chart.

Probes config was taken from config/manager/operator.yaml