### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver
+            type=semver,pattern={{version}}
             type=sha
 
       - name: Build and push


### PR DESCRIPTION
Seems we broke the release workflow in https://github.com/movetokube/postgres-operator/pull/255
This should fix the issue, and should fix https://github.com/movetokube/postgres-operator/issues/278