### PR TITLE
remove error in log message for PostgresUserReconciler.newSecretForCR

### DIFF
--- a/internal/controller/postgresuser_controller.go
+++ b/internal/controller/postgresuser_controller.go
@@ -322,7 +322,7 @@ func (r *PostgresUserReconciler) newSecretForCR(reqLogger logr.Logger, cr *dbv1a
 	if err != nil {
 		hostname = r.pgHost
 		port = "5432"
-		reqLogger.Error(err, fmt.Sprintf("failed to parse host and port from: '%s', using default port 5432", r.pgHost))
+		reqLogger.Info(fmt.Sprintf("failed to parse host and port from: '%s', using default port 5432", r.pgHost))
 	}
 
 	pgUserUrl := fmt.Sprintf("postgresql://%s:%s@%s/%s", role, password, r.pgHost, cr.Status.DatabaseName)


### PR DESCRIPTION
The newSecretForCR for the PostgresUserReconciler is setting an error in case the port is not defined. 

https://github.com/movetokube/postgres-operator/blob/615a675639af673790c58a113be1fc3b9faf0725/internal/controller/postgresuser_controller.go#L325

In the end this is not an error, specially cause the code sets it to the default one by itself. However it's sending a log error with the whole stack trace of the `err` being super verbose and being confusing.
A recommendation would be to set it maximum as a warning or log and specially not sending the whole stack trace of the `err`.
