### PR TITLE
Add OCI (Oracle Cloud Infrastructure) cloud provider support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ const (
 	CloudProviderAWS   CloudProvider = "AWS"
 	CloudProviderAzure CloudProvider = "Azure"
 	CloudProviderGCP   CloudProvider = "GCP"
+	CloudProviderOCI   CloudProvider = "OCI"
 )
 
 func Get() *Cfg {
@@ -61,6 +62,8 @@ func ParseCloudProvider(s string) CloudProvider {
 		return CloudProviderAzure
 	case "gcp":
 		return CloudProviderGCP
+	case "oci":
+		return CloudProviderOCI
 	default:
 		return CloudProviderNone
 	}

--- a/pkg/postgres/oci.go
+++ b/pkg/postgres/oci.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+type ocipg struct {
+	pg
+}
+
+func newOCIPG(postgres *pg) PG {
+	return &ocipg{
+		*postgres,
+	}
+}
+
+func (c *ocipg) CreateDB(dbname, role string) error {
+	// OCI managed Postgres admin user is not a true superuser; must belong to
+	// the role before ALTER DATABASE ... OWNER TO succeeds
+	err := c.GrantRole(role, c.user)
+	if err != nil {
+		return err
+	}
+
+	return c.pg.CreateDB(dbname, role)
+}
+
+func (c *ocipg) DropRole(role, newOwner, database string) error {
+	// Must belong to both roles for REASSIGN OWNED BY to succeed
+	err := c.GrantRole(role, c.user)
+	if err != nil && err.(*pq.Error).Code != "0LP01" {
+		if err.(*pq.Error).Code == "42704" {
+			return nil
+		}
+		return err
+	}
+	err = c.GrantRole(newOwner, c.user)
+	if err != nil && err.(*pq.Error).Code != "0LP01" {
+		if err.(*pq.Error).Code == "42704" {
+			c.log.Info(fmt.Sprintf("not granting %s to %s as %s does not exist", role, newOwner, newOwner))
+			return nil
+		}
+		return err
+	}
+	defer c.RevokeRole(newOwner, c.user)
+
+	return c.pg.DropRole(role, newOwner, database)
+}

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -79,6 +79,9 @@ func NewPG(cfg *config.Cfg, logger logr.Logger) (PG, error) {
 	case config.CloudProviderGCP:
 		logger.Info("Using GCP wrapper")
 		return newGCPPG(postgres), nil
+	case config.CloudProviderOCI:
+		logger.Info("Using OCI wrapper")
+		return newOCIPG(postgres), nil
 	default:
 		logger.Info("Using default postgres implementation")
 		return postgres, nil


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                 
  Oracle Cloud Infrastructure (OCI) managed PostgreSQL, like AWS RDS and GCP
  AlloyDB, does not grant the admin user full superuser privileges. This means                                                                                                   
  certain operations require the admin user to belong to the target                                                                                                  
  role(s) before they can succeed. Without a dedicated provider wrapper,
  `CreateDB` and `DropRole` fail against OCI PostgreSQL.                                                                                                                         
                                                                                                                                                                                 
  This PR adds an OCI provider wrapper that mirrors the workarounds already in                                                                                                   
  place for AWS and GCP:                                                                                                                                                         
                                                                                                                                                                                 
  - **`CreateDB`**: grants the admin user membership in the target role before                                                                                                   
    calling `ALTER DATABASE ... OWNER TO`, then delegates to the base
    implementation.                                                                                                                                                              
  - **`DropRole`**: grants the admin user membership in both the role being                                                                                                      
    dropped and the new owner role (required for `REASSIGN OWNED BY`), with
    appropriate handling for the "already a member" (`0LP01`) and "role does not                                                                                                 
    exist" (`42704`) error codes. The new-owner grant is revoked via `defer`                                                                                                     
    after the drop completes.                                                                                                                                                    
                                                                                                                                                                                 
  ## Changes                                                                                                                                                                     
                                                                                                                                                                               
  - `pkg/config/config.go`: add `CloudProviderOCI` constant and `"oci"` case in                                                                                                  
    `ParseCloudProvider`.
  - `pkg/postgres/oci.go`: new file implementing the `ocipg` wrapper with                                                                                                        
    `CreateDB` and `DropRole` overrides.                                                                                                                                         
  - `pkg/postgres/postgres.go`: wire `CloudProviderOCI` into the `NewPG` factory.
                                                                                                                                                                                 
  ## Testing                                                                                                                                                                   
                                                                                                                                                                                 
  Tested against an OCI PostgreSQL instance with the operator configured with                                                                                                    
  `cloudProvider: OCI`. Database and role lifecycle operations all complete successfully.                                                                                                                                     
